### PR TITLE
fix: remove role from create user request in auth client

### DIFF
--- a/src/main/kotlin/com/koosco/userservice/application/client/AuthServiceClient.kt
+++ b/src/main/kotlin/com/koosco/userservice/application/client/AuthServiceClient.kt
@@ -1,9 +1,8 @@
 package com.koosco.userservice.application.client
 
 import com.koosco.userservice.domain.vo.AuthProvider
-import com.koosco.userservice.domain.vo.UserRole
 
 interface AuthServiceClient {
 
-    fun notifyUserCreated(userId: Long, password: String, email: String, provider: AuthProvider?, role: UserRole)
+    fun notifyUserCreated(userId: Long, password: String, email: String, provider: AuthProvider?)
 }

--- a/src/main/kotlin/com/koosco/userservice/application/usecase/RegisterUseCase.kt
+++ b/src/main/kotlin/com/koosco/userservice/application/usecase/RegisterUseCase.kt
@@ -22,7 +22,6 @@ class RegisterUseCase(private val userService: UserService, private val authServ
                 password = dto.password,
                 email = dto.email,
                 provider = dto.provider,
-                role = user.role,
             )
         } catch (ex: Exception) {
             runCatching { userService.rollback(user) }

--- a/src/main/kotlin/com/koosco/userservice/infra/client/AuthClientAdapter.kt
+++ b/src/main/kotlin/com/koosco/userservice/infra/client/AuthClientAdapter.kt
@@ -4,7 +4,6 @@ import com.koosco.common.core.error.CommonErrorCode
 import com.koosco.common.core.exception.ExternalServiceException
 import com.koosco.userservice.application.client.AuthServiceClient
 import com.koosco.userservice.domain.vo.AuthProvider
-import com.koosco.userservice.domain.vo.UserRole
 import com.koosco.userservice.infra.client.dto.CreateUserRequest
 import feign.FeignException
 import org.springframework.stereotype.Component
@@ -12,13 +11,7 @@ import org.springframework.stereotype.Component
 @Component
 class AuthClientAdapter(private val authClient: AuthClient) : AuthServiceClient {
 
-    override fun notifyUserCreated(
-        userId: Long,
-        password: String,
-        email: String,
-        provider: AuthProvider?,
-        role: UserRole,
-    ) {
+    override fun notifyUserCreated(userId: Long, password: String, email: String, provider: AuthProvider?) {
         try {
             authClient.createUser(
                 CreateUserRequest(
@@ -26,7 +19,6 @@ class AuthClientAdapter(private val authClient: AuthClient) : AuthServiceClient 
                     email = email,
                     password = password,
                     provider = provider,
-                    role = role,
                 ),
             )
         } catch (e: FeignException) {

--- a/src/main/kotlin/com/koosco/userservice/infra/client/dto/AuthRequests.kt
+++ b/src/main/kotlin/com/koosco/userservice/infra/client/dto/AuthRequests.kt
@@ -1,14 +1,7 @@
 package com.koosco.userservice.infra.client.dto
 
 import com.koosco.userservice.domain.vo.AuthProvider
-import com.koosco.userservice.domain.vo.UserRole
 
-data class CreateUserRequest(
-    val userId: Long,
-    val email: String,
-    val password: String,
-    val provider: AuthProvider?,
-    val role: UserRole,
-)
+data class CreateUserRequest(val userId: Long, val email: String, val password: String, val provider: AuthProvider?)
 
 data class DeleteUserRequest(val userId: Long)


### PR DESCRIPTION
## summary
* AuthClient.createUser : USER ROLE 정보 삭제
* USER_ROLE은 사용자 정보로, 인증, 인가 서비스에서 직접적으로 저장하는 대신에 user service를 조회하여 얻도록 수정