### PR TITLE
perf: build docker image by copying prebuilt jar only

### DIFF
--- a/scripts/deploy-k8s.sh
+++ b/scripts/deploy-k8s.sh
@@ -68,12 +68,16 @@ case ${ENVIRONMENT} in
         echo "  Token: ${GH_TOKEN:0:4}****"
         echo ""
 
+        # Gradle로 jar 빌드
+        echo "Building jar file with Gradle..."
+        cd ${PROJECT_DIR}
+        ./gradlew bootJar
+        echo -e "${GREEN}✓${NC} Jar built successfully"
+        echo ""
+
         # Docker 이미지 빌드
         echo "Building Docker image..."
-        docker build \
-          --build-arg GH_USER=${GH_USER} \
-          --build-arg GH_TOKEN=${GH_TOKEN} \
-          -t ${IMAGE_NAME}:${IMAGE_TAG} ${PROJECT_DIR}
+        docker build -t ${IMAGE_NAME}:${IMAGE_TAG} ${PROJECT_DIR}
         echo -e "${GREEN}✓${NC} Image built successfully"
         echo ""
 
@@ -154,12 +158,16 @@ case ${ENVIRONMENT} in
         echo "Target k3d cluster: ${CLUSTER_NAME}"
         echo ""
 
+        # Gradle로 jar 빌드
+        echo "Building jar file with Gradle..."
+        cd ${PROJECT_DIR}
+        ./gradlew bootJar
+        echo -e "${GREEN}✓${NC} Jar built successfully"
+        echo ""
+
         # Docker 이미지 빌드
         echo "Building Docker image..."
-        docker build \
-          --build-arg GH_USER=${GH_USER} \
-          --build-arg GH_TOKEN=${GH_TOKEN} \
-          -t ${IMAGE_NAME}:${IMAGE_TAG} ${PROJECT_DIR}
+        docker build -t ${IMAGE_NAME}:${IMAGE_TAG} ${PROJECT_DIR}
         echo -e "${GREEN}✓${NC} Image built successfully"
         echo ""
 
@@ -224,12 +232,16 @@ case ${ENVIRONMENT} in
         echo -e "${GREEN}✓${NC} SSH connection successful"
         echo ""
 
+        # Gradle로 jar 빌드
+        echo "Building jar file with Gradle..."
+        cd ${PROJECT_DIR}
+        ./gradlew bootJar
+        echo -e "${GREEN}✓${NC} Jar built successfully"
+        echo ""
+
         # Docker 이미지 빌드
         echo "Building Docker image..."
-        docker build \
-          --build-arg GH_USER=${GH_USER} \
-          --build-arg GH_TOKEN=${GH_TOKEN} \
-          -t ${IMAGE_NAME}:${IMAGE_TAG} ${PROJECT_DIR}
+        docker build -t ${IMAGE_NAME}:${IMAGE_TAG} ${PROJECT_DIR}
         echo -e "${GREEN}✓${NC} Image built successfully"
         echo ""
 


### PR DESCRIPTION
## summary
* docker build 시간 단축을 위해 빌드된 jar만 COPY하도록 수정

## details
### 기존 방식의 문제점
기존 Dockerfile은 멀티 스테이지 빌드 구조로, Docker build 과정에서 Gradle을 실행하여 애플리케이션을 직접 빌드하고 있었다.

이 방식은 정석적인 예제로는 많이 사용되지만, Docker는 기본적으로 파일 변경 여부를 기준으로 레이어 캐시를 판단하고, CPU, memory를 적극적으로 활용하는 빌드 작업에는 최적화되어 있지 않다. gradle은 CPU 사용량이 높고, memory와 disk IO를 많이 소모하며 캐시 구조가 복잡하다. 따라서 Dockerfile 내에서의 gradle build는 불필요하게 많은 빌드 시간을 소모하게 하며, 인스턴스 장애로까지 전파되는 문제가 발생하였다.

기존 방식은 Docker Layer Cache와 Gradle 내부 캐시로, 이중 캐시 구조가 발생하였다. 이로 인해 의존성이 변경되지 않아도 Docker Layer가 재사용되거나 반대로 작은 파일 변경에도 캐시가 무효화되어 의존성을 다시 다운로드하는 문제가 발생하였다.

Docker는 COPY 명령을 기준으로 캐시를 판단하기 때문에 기존 구조에서는 소스 코드 변경 시 의존성 다운로드 단계까지 캐시가 깨질 가능성이 높았다. 결과적으로 실제로는 바뀌지 않은 의존성까지 다시 받아오며 빌드 시간이 기하급수적으로 증가하게 되었다.

### 해결
gradle build를 Dockerfile 외부에서 수행하고, Docker는 생성된 jar에 대해 패키징만 담당하도록 역할을 분리한다. 로컬이나 CI에서 gradlew bootJar를 통해 jar 파일을 생성하고, Docker는 jar를 COPY한다. Docker는 런타임 환경만을 구성하기 때문에 기존에 문제가 되었던 Docker build 시간을 대폭 감소시키면서도 이중 캐시 구조 문제를 함께 해결하였다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized build workflow by separating jar compilation from Docker image creation.
  * Enhanced container security with non-root user execution and health checks.
  * Streamlined deployment pipeline across all environments with consistent build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->